### PR TITLE
add message size limit checks

### DIFF
--- a/src/gRPCClient.jl
+++ b/src/gRPCClient.jl
@@ -7,8 +7,11 @@ using ProtoBuf
 import Downloads: Curl
 import ProtoBuf: call_method
 
-export gRPCController, gRPCChannel, gRPCException, gRPCStatus, gRPCCheck
+export gRPCController, gRPCChannel, gRPCException, gRPCServiceCallException, gRPCMessageTooLargeException, gRPCStatus, gRPCCheck
 
+abstract type gRPCException <: Exception end
+
+include("limitio.jl")
 include("curl.jl")
 include("grpc.jl")
 include("generate.jl")

--- a/src/limitio.jl
+++ b/src/limitio.jl
@@ -1,0 +1,46 @@
+# limits number of bytes written to an io stream (originally from https://github.com/JuliaDebug/Debugger.jl/blob/master/src/limitio.jl)
+# useful to detect messages that would go over limit when converted to bytes.
+mutable struct LimitIO{IO_t <: IO} <: IO
+    io::IO_t
+    maxbytes::Int
+    n::Int # max bytes to write
+end
+LimitIO(io::IO, maxbytes) = LimitIO(io, maxbytes, 0)
+
+function Base.write(io::LimitIO, v::UInt8)
+    io.n > io.maxbytes && throw(gRPCMessageTooLargeException(io.maxbytes, io.n))
+    nincr = write(io.io, v)
+    io.n += nincr
+    nincr
+end
+
+"""
+Default maximum gRPC message size
+"""
+const DEFAULT_MAX_MESSAGE_LENGTH = 1024*1024*4
+
+"""
+    struct gRPCMessageTooLargeException
+        limit::Int
+        encountered::Int
+    end
+
+A `gRPMessageTooLargeException` exception is thrown when a message is
+encountered that has a size greater than the limit configured.
+Specifically, `max_recv_message_length` while receiving  and
+`max_send_message_length` while sending.
+
+A `gRPMessageTooLargeException` has the following members:
+
+- `limit`: the limit value that was exceeded
+- `encountered`: the amount of data that was actually received
+    or sent before this error was triggered. Note that this may
+    not correspond to the full size of the data, as error may be
+    thrown before actually materializing the complete data.
+"""
+struct gRPCMessageTooLargeException <: gRPCException
+    limit::Int
+    encountered::Int
+end
+
+Base.show(io::IO, m::gRPCMessageTooLargeException) = print(io, "gRPMessageTooLargeException($(m.limit), $(m.encountered)) - Encountered message size $(m.encountered) > max configured $(m.limit)")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,7 +72,7 @@ server_endpoint = isempty(ARGS) ? "http://localhost:10000/" : ARGS[1]
 
     serverproc = start_server()
 
-    @info("testing routeclinet...")
+    @debug("testing routeclinet...")
     test_clients(server_endpoint)
 
     kill(serverproc)


### PR DESCRIPTION
`gRPCController` now has additional parameters to limit both send and receive message sizes,
the default being 4MB. A `gRPCMessageTooLargeException` is thrown if that is exceeded.

`gRPCException` is now an abstact type with `gRPCMessageTooLargeException` and
`gRPCServiceCallException` as the two concrete implementations.