### PR TITLE
use protobuf codegen enhancements

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -1,6 +1,5 @@
 const package_regex = r"package\s(\S*)[\s]*;.*"
 const service_regex = r"service\s(\S*)[\s]*{.*"
-const services_option_regex = r"option\s[a-z]*_generic_services[\s]*=[\s]*true[\s]*;"
 
 function write_header(io, package, client_module_name)
     print(io, """module $(client_module_name)
@@ -89,19 +88,6 @@ function write_service_method(io, package, service, method)
     """)
 end
 
-function has_services_enabled(proto::String)
-    enabled = false
-    for line in readlines(proto)
-        line = strip(line)
-        regexmatches = match(services_option_regex, line)
-        if (regexmatches !== nothing)
-            enabled = true
-            break
-        end
-    end
-    enabled
-end
-
 function detect_services(proto::String)
     package = ""
     services = String[]
@@ -148,11 +134,6 @@ function generate(proto::String; outdir::String=pwd())
     proto = abspath(proto)
 
     @info("Generating gRPC client", proto, outdir)
-
-    # ensure services are enabled in proto file
-    if !has_services_enabled(proto)
-        throw(ArgumentError("Service generation must be enabled in $proto, e.g. option py_generic_services = true;"))
-    end
 
     # determine the package name and service name
     package, services = detect_services(proto)

--- a/test/RouteguideClients/route_guide.proto
+++ b/test/RouteguideClients/route_guide.proto
@@ -18,8 +18,6 @@ option go_package = "google.golang.org/grpc/examples/route_guide/routeguide";
 option java_multiple_files = true;
 option java_package = "io.grpc.examples.routeguide";
 option java_outer_classname = "RouteGuideProto";
-option py_generic_services = true;
-option java_generic_services = true;
 
 package routeguide;
 

--- a/test/RouteguideClients/route_guide_pb.jl
+++ b/test/RouteguideClients/route_guide_pb.jl
@@ -203,10 +203,10 @@ end
 
 # service methods for RouteGuide
 const _RouteGuide_methods = MethodDescriptor[
-        MethodDescriptor("GetFeature", 1, routeguide.Point, routeguide.Feature),
-        MethodDescriptor("ListFeatures", 2, routeguide.Rectangle, Channel{routeguide.Feature}),
-        MethodDescriptor("RecordRoute", 3, Channel{routeguide.Point}, routeguide.RouteSummary),
-        MethodDescriptor("RouteChat", 4, Channel{routeguide.RouteNote}, Channel{routeguide.RouteNote})
+        MethodDescriptor("GetFeature", 1, Point, Feature),
+        MethodDescriptor("ListFeatures", 2, Rectangle, Channel{Feature}),
+        MethodDescriptor("RecordRoute", 3, Channel{Point}, RouteSummary),
+        MethodDescriptor("RouteChat", 4, Channel{RouteNote}, Channel{RouteNote})
     ] # const _RouteGuide_methods
 const _RouteGuide_desc = ServiceDescriptor("routeguide.RouteGuide", 1, _RouteGuide_methods)
 
@@ -222,16 +222,16 @@ mutable struct RouteGuideBlockingStub <: AbstractProtoServiceStub{true}
     RouteGuideBlockingStub(channel::ProtoRpcChannel) = new(ProtoServiceBlockingStub(_RouteGuide_desc, channel))
 end # mutable struct RouteGuideBlockingStub
 
-GetFeature(stub::RouteGuideStub, controller::ProtoRpcController, inp::routeguide.Point, done::Function) = call_method(stub.impl, _RouteGuide_methods[1], controller, inp, done)
-GetFeature(stub::RouteGuideBlockingStub, controller::ProtoRpcController, inp::routeguide.Point) = call_method(stub.impl, _RouteGuide_methods[1], controller, inp)
+GetFeature(stub::RouteGuideStub, controller::ProtoRpcController, inp::Point, done::Function) = call_method(stub.impl, _RouteGuide_methods[1], controller, inp, done)
+GetFeature(stub::RouteGuideBlockingStub, controller::ProtoRpcController, inp::Point) = call_method(stub.impl, _RouteGuide_methods[1], controller, inp)
 
-ListFeatures(stub::RouteGuideStub, controller::ProtoRpcController, inp::routeguide.Rectangle, done::Function) = call_method(stub.impl, _RouteGuide_methods[2], controller, inp, done)
-ListFeatures(stub::RouteGuideBlockingStub, controller::ProtoRpcController, inp::routeguide.Rectangle) = call_method(stub.impl, _RouteGuide_methods[2], controller, inp)
+ListFeatures(stub::RouteGuideStub, controller::ProtoRpcController, inp::Rectangle, done::Function) = call_method(stub.impl, _RouteGuide_methods[2], controller, inp, done)
+ListFeatures(stub::RouteGuideBlockingStub, controller::ProtoRpcController, inp::Rectangle) = call_method(stub.impl, _RouteGuide_methods[2], controller, inp)
 
-RecordRoute(stub::RouteGuideStub, controller::ProtoRpcController, inp::Channel{routeguide.Point}, done::Function) = call_method(stub.impl, _RouteGuide_methods[3], controller, inp, done)
-RecordRoute(stub::RouteGuideBlockingStub, controller::ProtoRpcController, inp::Channel{routeguide.Point}) = call_method(stub.impl, _RouteGuide_methods[3], controller, inp)
+RecordRoute(stub::RouteGuideStub, controller::ProtoRpcController, inp::Channel{Point}, done::Function) = call_method(stub.impl, _RouteGuide_methods[3], controller, inp, done)
+RecordRoute(stub::RouteGuideBlockingStub, controller::ProtoRpcController, inp::Channel{Point}) = call_method(stub.impl, _RouteGuide_methods[3], controller, inp)
 
-RouteChat(stub::RouteGuideStub, controller::ProtoRpcController, inp::Channel{routeguide.RouteNote}, done::Function) = call_method(stub.impl, _RouteGuide_methods[4], controller, inp, done)
-RouteChat(stub::RouteGuideBlockingStub, controller::ProtoRpcController, inp::Channel{routeguide.RouteNote}) = call_method(stub.impl, _RouteGuide_methods[4], controller, inp)
+RouteChat(stub::RouteGuideStub, controller::ProtoRpcController, inp::Channel{RouteNote}, done::Function) = call_method(stub.impl, _RouteGuide_methods[4], controller, inp, done)
+RouteChat(stub::RouteGuideBlockingStub, controller::ProtoRpcController, inp::Channel{RouteNote}) = call_method(stub.impl, _RouteGuide_methods[4], controller, inp)
 
 export Point, Rectangle, Feature, RouteNote, RouteSummary, RouteGuide, RouteGuideStub, RouteGuideBlockingStub, GetFeature, ListFeatures, RecordRoute, RouteChat


### PR DESCRIPTION
Use updated ProtoBuf.jl that:
- does not depend on service generation flags for other languages, removed corresponding checks here
- allows service parameters that are nested message structs