### PR TITLE
change service detect regex to cope with linebreak

### DIFF
--- a/src/generate.jl
+++ b/src/generate.jl
@@ -1,5 +1,5 @@
 const package_regex = r"package\s(\S*)[\s]*;.*"
-const service_regex = r"service\s(\S*)[\s]*{.*"
+const service_regex = r"service\s(\S*)[\s]*.*"
 
 function write_header(io, generated_module, package, client_module_name)
     print(io, """module $(client_module_name)
@@ -99,7 +99,7 @@ function detect_services(proto::String)
             if (regexmatches !== nothing) && (length(regexmatches.captures) == 1)
                 package = string(first(regexmatches.captures))
             end
-        elseif startswith(strip(line), "service")
+        elseif startswith(line, "service")
             regexmatches = match(service_regex, line)
             if (regexmatches !== nothing) && (length(regexmatches.captures) == 1)
                 service = string(first(regexmatches.captures))

--- a/test/GrpcerrorsClients/grpcerrors_pb.jl
+++ b/test/GrpcerrorsClients/grpcerrors_pb.jl
@@ -15,7 +15,9 @@ mutable struct Data <: ProtoType
             fldname, fldval = nv
             fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
-            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            if fldval !== nothing
+                values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            end
         end
         obj
     end

--- a/test/RouteguideClients/route_guide_pb.jl
+++ b/test/RouteguideClients/route_guide_pb.jl
@@ -15,7 +15,9 @@ mutable struct Point <: ProtoType
             fldname, fldval = nv
             fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
-            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            if fldval !== nothing
+                values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            end
         end
         obj
     end
@@ -54,7 +56,9 @@ mutable struct Rectangle <: ProtoType
             fldname, fldval = nv
             fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
-            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            if fldval !== nothing
+                values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            end
         end
         obj
     end
@@ -93,7 +97,9 @@ mutable struct Feature <: ProtoType
             fldname, fldval = nv
             fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
-            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            if fldval !== nothing
+                values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            end
         end
         obj
     end
@@ -132,7 +138,9 @@ mutable struct RouteNote <: ProtoType
             fldname, fldval = nv
             fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
-            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            if fldval !== nothing
+                values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            end
         end
         obj
     end
@@ -171,7 +179,9 @@ mutable struct RouteSummary <: ProtoType
             fldname, fldval = nv
             fldtype = symdict[fldname].jtyp
             (fldname in keys(symdict)) || error(string(typeof(obj), " has no field with name ", fldname))
-            values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            if fldval !== nothing
+                values[fldname] = isa(fldval, fldtype) ? fldval : convert(fldtype, fldval)
+            end
         end
         obj
     end


### PR DESCRIPTION
fixes #14

Updates service detection regex to match with cases where `{` is placed after a line break.
Also removed a superfluous strip.