### PR TITLE
set the TE header by default in requests

### DIFF
--- a/src/curl.jl
+++ b/src/curl.jl
@@ -80,6 +80,7 @@ function grpc_headers(; timeout::Real=Inf)
     headers = LibCURL.curl_slist_append(headers, "User-Agent: $(Curl.USER_AGENT)")
     headers = LibCURL.curl_slist_append(headers, "Content-Type: application/grpc+proto")
     headers = LibCURL.curl_slist_append(headers, "Content-Length:")
+    headers = LibCURL.curl_slist_append(headers, "te: trailers")
     if timeout !== Inf
         headers = LibCURL.curl_slist_append(headers, "grpc-timeout: $(grpc_timeout_header_val(timeout))")
     end


### PR DESCRIPTION
Some gRPC servers and proxies may need to be presented with a [`te` header](https://datatracker.ietf.org/doc/html/rfc7230#section-4.3). In gRPC trailers are always allowed in the protocol, but we encountered a scenario (#15) where the Python gRPC server implementation insists on it being [specified explicitly](https://nghttp2.org/blog/2015/03/24/proxying-grpc-with-nghttpx/).

This PR sets the TE header to `trailers` by default in every request.

fixes #15