### PR TITLE
make compatible to Julia 1.7 Downloads.jl updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "gRPCClient"
 uuid = "aaca4a50-36af-4a1d-b878-4c443f2061ad"
 authors = ["Tanmay K.M. <tanmaykm@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
@@ -9,10 +9,10 @@ LibCURL = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 
 [compat]
-Downloads = "1.3"
+Downloads = "1.4"
 LibCURL = "0.6"
 ProtoBuf = "0.11"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/curl.jl
+++ b/src/curl.jl
@@ -188,7 +188,11 @@ function grpc_request(downloader::Downloader, url::String, input::Channel{T1}, o
         Curl.set_timeout(easy, request_timeout)
         set_connect_timeout(easy, connect_timeout)
         Curl.set_verbose(easy, verbose)
-        Curl.add_upload_callbacks(easy)
+        if isdefined(Curl, :add_upload_callbacks)
+            Curl.add_upload_callbacks(easy)
+        else
+            Curl.add_upload_callback(easy)
+        end
         Downloads.set_ca_roots(downloader, easy)
 
         # do the request


### PR DESCRIPTION
Handle Downloads.jl method rename after https://github.com/JuliaLang/Downloads.jl/pull/170/commits/5bd08265f529123f2d54bc0104d6f59e86c0c1f7
Should fix #25, gRPC client hanging in Julia 1.7.3