### PR TITLE
fix max limit for connect timeout

### DIFF
--- a/src/curl.jl
+++ b/src/curl.jl
@@ -215,15 +215,10 @@ function recv_data(easy::Curl.Easy, output::Channel{T}, max_recv_message_length:
 end
 
 function set_connect_timeout(easy::Curl.Easy, timeout::Real)
-    timeout >= 0 ||
+    (0 ≤ timeout ≤ (typemax(Clong) ÷ 1000)) ||
         throw(ArgumentError("timeout must be positive, got $timeout"))
-    if timeout ≤ typemax(Clong) ÷ 1000
-        timeout_ms = round(Clong, timeout * 1000)
-        Curl.setopt(easy, CURLOPT_CONNECTTIMEOUT_MS, timeout_ms)
-    else
-        timeout = timeout ≤ typemax(Clong) ? round(Clong, timeout) : Clong(0)
-        Curl.setopt(easy, CURLOPT_CONNECTTIMEOUT, timeout)
-    end
+    timeout_ms = round(Clong, timeout * 1000)
+    Curl.setopt(easy, CURLOPT_CONNECTTIMEOUT_MS, timeout_ms)
 end
 
 # Prevent reuse of this handle

--- a/src/grpc.jl
+++ b/src/grpc.jl
@@ -90,8 +90,8 @@ Contains settings to control the behavior of gRPC requests.
    tls), or `:http2` (http2 upgrade)
 - `revocation`: whether to check for certificate recovation (default is true)
 - `request_timeout`: request timeout (seconds)
-- `connect_timeout`: connect timeout (seconds) (default is 300 seconds, same
-   as setting this to 0)
+- `connect_timeout`: connect timeout (seconds) (must be ≤ typemax(Clong)÷1000,
+    default is 300 seconds, same as setting this to 0)
 - `max_message_length`: maximum message length (default is 4MB)
 - `max_recv_message_length`: maximum message length to receive (default is
    `max_message_length`, same as setting this to 0)
@@ -126,7 +126,8 @@ struct gRPCController <: ProtoRpcController
             enable_shared_locks::Bool = false,
             verbose::Bool = false
         )
-        if maxage < 0 || keepalive < 0 || request_timeout < 0 || connect_timeout < 0 || 
+        if maxage < 0 || keepalive < 0 || request_timeout < 0 || 
+            connect_timeout < 0 || connect_timeout > (typemax(Clong) ÷ 1000) ||
             max_message_length < 0 || max_recv_message_length < 0 || max_send_message_length < 0
             throw(ArgumentError("Invalid gRPCController parameter"))
         end

--- a/test/test_grpcerrors.jl
+++ b/test/test_grpcerrors.jl
@@ -144,9 +144,13 @@ end
 
 function test_connect_timeout()
     timeout_server_endpoint = "http://10.255.255.1/" # a non routable IP
-    timeout_secs = 5
-    client = GRPCErrorsBlockingClient(timeout_server_endpoint; verbose=false, connect_timeout=timeout_secs)
+
     @testset "connect timeout" begin
+        @test_throws ArgumentError GRPCErrorsBlockingClient(timeout_server_endpoint; verbose=false, connect_timeout=typemax(Clong))
+        @test_throws ArgumentError GRPCErrorsBlockingClient(timeout_server_endpoint; verbose=false, connect_timeout=-1)
+
+        timeout_secs = 5
+        client = GRPCErrorsBlockingClient(timeout_server_endpoint; verbose=false, connect_timeout=timeout_secs)
         data = GrpcerrorsClients.Data(; mode=1, param=0)
         t1 = time()
         try


### PR DESCRIPTION
This adds an upper limit to the connect timeout value that can be specified,
to limit it to `typemax(Clong) ÷ 1000`. An `ArgumentError` is thrown if the
value is out of range.

This matches what libcurl expects [here](https://github.com/curl/curl/blob/4a8f6869db3a4ba7cd1bcb153c3d5b4298728afa/lib/setopt.c#L1376).

Originally reported by @manuelbb-upb at https://github.com/JuliaLang/Downloads.jl/issues/193 and https://github.com/JuliaComputing/gRPCClient.jl/pull/23.