### PR TITLE
tag 1.0 with ProtoBuf pinned to working version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "gRPCClient"
 uuid = "aaca4a50-36af-4a1d-b878-4c443f2061ad"
 authors = ["Tanmay K.M. <tanmaykm@gmail.com>"]
-version = "0.1.4"
+version = "1.0.0"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
@@ -11,7 +11,7 @@ ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 [compat]
 Downloads = "1.4"
 LibCURL = "0.6"
-ProtoBuf = "0.11"
+ProtoBuf = "~0.11"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
gRPCClient.jl requires ProtoBuf v0.11. It is incompatible with 1.x versions of ProtoBuf as it was a significant rewrite and protobuf services are not yet supported there. This PR is to pin ProtoBuf version requirement to v0.11 and tag a new release of gRPCClient.